### PR TITLE
Adding support for changes to admin list API

### DIFF
--- a/test/kafka-mock.js
+++ b/test/kafka-mock.js
@@ -49,14 +49,19 @@ var MockService = function(verbose) {
   */
   this.app.route('/admin/topics')
     .get(function(request, response, next) {
-      response.send(JSON.stringify(instance.topics));
+      var listResponse = [];
+      for(var index in instance.topics) {
+         var jsonString = "{\"name\":\"" +instance.topics[index] +"\",\"isMarkedForDeletion\":\"false\"}"
+         listResponse.push(JSON.parse(jsonString));
+      }
+      response.send(JSON.stringify(listResponse));
     })
     .post(function(request, response, next) {
       if(typeof(request.body.topicName) === 'string') {
         var inList = false;
 
         for(var index in instance.topics) {
-          if(instance.topics[index] === request.body.topicName) {
+          if(instance.topics[index].name === request.body.topicName) {
             inList = true;
           }
         }

--- a/test/spec/Topics.spec.js
+++ b/test/spec/Topics.spec.js
@@ -127,17 +127,17 @@ module.exports.run = function(services, port, useMockService) {
         .then(function(response) {
           var inList = false;
           var index = 0;
-
           // Search for the topic, if it is not in the list
           // the test fails.
           while(index < response.length && !inList) {
-            if(response[index] === input) {
+            if(response[index].name === input) {
               inList = true;
             }
 
             index++;
           }
 
+          console.log("inlist" +inList);
           if(!inList) {
             done(new Error('Topic ' + input + ' not in list after ' + timeout + ' milliseconds.'));
           }

--- a/test/spec/Topics.spec.js
+++ b/test/spec/Topics.spec.js
@@ -137,7 +137,6 @@ module.exports.run = function(services, port, useMockService) {
             index++;
           }
 
-          console.log("inlist" +inList);
           if(!inList) {
             done(new Error('Topic ' + input + ' not in list after ' + timeout + ' milliseconds.'));
           }


### PR DESCRIPTION
The admin list API now returns an array of the form:

[ { name: 'topic1', isMarkedForDeletion: false },
  { name: 'topic2', isMarkedForDeletion: false },
  { name: 'topic3', isMarkedForDeletion: false } ]

This pull request makes the corresponding changes to handle this.
