### PR TITLE
Removing support for topicName parameter in topic create

### DIFF
--- a/lib/messagehub.js
+++ b/lib/messagehub.js
@@ -133,7 +133,7 @@ Client.prototype.topics.create = function(topic) {
         ignoredErrorCodes: [422]
       },
       {
-        topicName: topic
+        name: topic
       });
   } else {
     var deferred = Q.defer();

--- a/test/kafka-mock.js
+++ b/test/kafka-mock.js
@@ -52,17 +52,17 @@ var MockService = function(verbose) {
       response.send(JSON.stringify(instance.topics));
     })
     .post(function(request, response, next) {
-      if(typeof(request.body.topicName) === 'string') {
+      if(typeof(request.body.name) === 'string') {
         var inList = false;
 
         for(var index in instance.topics) {
-          if(instance.topics[index] === request.body.topicName) {
+          if(instance.topics[index] === request.body.name) {
             inList = true;
           }
         }
 
         if(!inList) {
-          instance.topics.push(request.body.topicName);
+          instance.topics.push(request.body.name);
           response.sendStatus(202);
         } else {
           response.sendStatus(422);


### PR DESCRIPTION
For consistency we're removing support for the parameter "topicName" in the topic create REST call and replacing it with "name". This pull request makes the necessary changes to the sample to handle this.
