### PR TITLE
Ensure there's only one request per topic per consumer instance out at a given time

### DIFF
--- a/lib/messagehub.js
+++ b/lib/messagehub.js
@@ -256,12 +256,16 @@ var ConsumerInstance = Client.ConsumerInstance = function(client, groupName, ins
     throw new TypeError('Provided client parameter must be an instance of Client.');
   }
 
-  configure = configure || true;
+  configure = typeof configure === 'boolean' ? configure : true;
 
   this.client = client;
   this.groupName = groupName;
   this.instanceName = instanceName;
   this.options = options;
+  // a map to keep track of topic -> request promise. we will use this to
+  // ensure that only one request per consumer isntance per topic is pending
+  // at a given time - avoids kafka errors
+  this._topicGetMap = {};
 
   if(configure) {
     this.configure();
@@ -342,6 +346,14 @@ ConsumerInstance.prototype.configure = function() {
  *                    to the service resolves.
 */
 ConsumerInstance.prototype.get = function(topicName, toValue) {
+  // if there's already a promise pending for a given topic, return that instead
+  // of issuing a new get. this prevents the Kafka error: `Another request is in
+  // progress for consumer "test:test1". Request may be retried when response is
+  // received for the previous request.
+  if (this._topicGetMap[topicName]) {
+    return this._topicGetMap[topicName];
+  }
+  // if we don't have a request already "out", proceed with business as usual
   if(toValue !== undefined && typeof(toValue) !== 'boolean') {
     console.warn('Provided parameter toValue is not a boolean, defaulting to true.');
     toValue = true;
@@ -363,21 +375,27 @@ ConsumerInstance.prototype.get = function(topicName, toValue) {
     https: this.client.config.https,
   });
 
-  // Convert the response to pure values without
-  // Kafka metadata.
+  // Convert the response to pure values without Kafka metadata.
+  var prom;
   if(toValue) {
-    return req.then(function(data) {
+    prom = req.then(function(data) {
       var output = [];
-
       for(var index in data) {
         output.push(new Buffer(data[index].value, 'base64').toString('utf8'));
       }
-
       return output;
     });
   } else {
-    return req;
+    prom = req;
   }
+  // keep track of the promise in our topic map, make sure to clean up when
+  // request is complete
+  this._topicGetMap[topicName] = prom.then(function() {
+    delete this._topicGetMap[topicName];
+    // return all arguments to ensure proper promise chaining
+    return arguments;
+  }.bind(this));
+  return prom;
 };
 
 /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -86,8 +86,8 @@ module.exports.request = function(requestOptions, options, body) {
 
       try {
         result = JSON.parse(responseData);
-        errorCode = result.errorCode;
-        errorMessage = result.errorMessage;
+        errorCode = result.errorCode || result.error_code;
+        errorMessage = result.errorMessage || result.message;
       } catch(e) {
         result = responseData;
       }


### PR DESCRIPTION
Add `_topicGetMap` to ConsumerInstance. Every time `ConsumerInstance.get()` is issued - keep track of the promise for that topic. If a new get is issued for the same topic, return the existing promise. Do necessary cleanup when request is finished.

Without this, you get errors that look like:

``` sh
[Error: Request returned status code 500 but it was not in the accepted list. The
REST API responded with the following message: Another request is in progress
for consumer "test:test1". Request may be retried when response is received for
the previous request.]
```
