### PR TITLE
ConsumerInstance.prototype.get: Promise caching error

### DIFF
--- a/lib/messagehub.js
+++ b/lib/messagehub.js
@@ -427,10 +427,10 @@ ConsumerInstance.prototype.get = function(topicName, toValue) {
 
   // Keep track of the promise in our topic map, make sure to clean up when
   // request is complete
-  this._topicGetMap[topicName] = prom.then(function() {
+  this._topicGetMap[topicName] = prom.then(function(response) {
     delete this._topicGetMap[topicName];
-    // return all arguments to ensure proper promise chaining
-    return arguments;
+    // promises only return one value
+    return response;
   }.bind(this));
 
   return prom;


### PR DESCRIPTION
`ConsumerIntances.prototype.get` has a caching method when there is a pending promise for a given topic.

When this method is queried several times, only the first promise has the correct output, the following ones have incorrect responses.

Example:
```javascript
const MessageHub = require('message-hub-rest');
const instance = new MessageHub(config);
instance
  .consume('a-nice-group', 'a-nice-id', {'auto.offset.reset': 'largest'})
  .then(consumers => consumers[0])
  .then(consumer => {
    consumer.get('topic').then(d => console.log(d));
    // Outputs: `[]`
    consumer.get('topic').then(d => console.log(d));
    // Outputs: `{ '0': [] }`
    consumer.get('topic').then(d => console.log(d));
    // Outputs: `{ '0': [] }`
  });
```

This PR fixes this issue.