### PR TITLE
Key off of 'kafka_admin_url' instead of 'kafka_rest_url', bump versio…

### DIFF
--- a/lib/messagehub.js
+++ b/lib/messagehub.js
@@ -70,7 +70,7 @@ var Client = function(services, opts) {
       }
 
       this.apiKey = services[serviceName][serviceIndex].credentials.api_key;
-      this.url = Url.parse(services[serviceName][serviceIndex].credentials.kafka_rest_url);
+      this.url = Url.parse(services[serviceName][serviceIndex].credentials.kafka_admin_url);
       this.consumerInstances = { };
     } else {
       throw new Error(serviceNamePrefix + '* is not provided in the services environment variable. ' +

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "message-hub-rest",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Node.js module for connecting to the Kafka REST interface of IBM Message Hub.",
   "main": "lib/messagehub.js",
   "repository": {
@@ -8,7 +8,7 @@
     "url": "https://github.com/ibm-messaging/message-hub-rest"
   },
   "engines": {
-    "node" : ">=0.12"
+    "node": ">=0.12"
   },
   "scripts": {
     "test": "mocha --bail -t 60000 ./test/run-tests.js"

--- a/test/run-tests.js
+++ b/test/run-tests.js
@@ -75,7 +75,7 @@ if(useMockService) {
          "plan": "beta",
          "credentials": {
             "api_key": "an_api_key",
-            "kafka_rest_url": "http://localhost:" + PORT,
+            "kafka_admin_url": "http://localhost:" + PORT,
          }
       }
    ];
@@ -95,7 +95,7 @@ if(useMockService) {
       "label": "messagehub",
       "credentials": {
         "api_key": argApiKey,
-        "kafka_rest_url": argRestUrl,
+        "kafka_admin_url": argRestUrl,
       }
     }
   ];

--- a/test/spec/Utils.spec.js
+++ b/test/spec/Utils.spec.js
@@ -45,7 +45,7 @@ module.exports.run = function(services, port, useMockService) {
       requestOptions.port = port;
       requestOptions.headers['X-Auth-Token'] = 'an_api_key';
     } else {
-      var url = Url.parse(services["messagehub"][0].credentials.kafka_rest_url);
+      var url = Url.parse(services["messagehub"][0].credentials.kafka_admin_url);
       requestOptions.host = url.hostname;
       requestOptions.port = url.port;
       requestOptions.headers['X-Auth-Token'] = services["messagehub"][0].credentials.api_key;


### PR DESCRIPTION
…n from 1.2.0 to 1.3.0